### PR TITLE
Add microsoft/git and Scalar packages

### DIFF
--- a/Casks/scalar-azrepos.rb
+++ b/Casks/scalar-azrepos.rb
@@ -1,0 +1,22 @@
+cask 'scalar-azrepos' do
+  version '20.04.168.2'
+  sha256 'd10a6b8ae84f9ba4251a77983e8117554f3a19223fb7287ae2fa179410d51b4b'
+
+  url "https://github.com/microsoft/scalar/releases/download/v#{version}/Installers_macOS_Release.zip"
+
+  name 'Scalar for Azure Repos'
+  homepage 'https://github.com/microsoft/scalar'
+
+  pkg "Installers_macOS_Release/Scalar/Scalar.#{version}.pkg", allow_untrusted: true
+
+  conflicts_with cask: 'scalar'
+
+  depends_on formula: 'microsoft-git'
+  depends_on cask: 'git-credential-manager-core'
+
+  uninstall script: {
+                      executable: '/usr/local/scalar/uninstall_scalar.sh',
+                      sudo:       true,
+                    },
+            pkgutil: 'com.scalar.pkg'
+end

--- a/Formula/microsoft-git.rb
+++ b/Formula/microsoft-git.rb
@@ -1,0 +1,189 @@
+# Modifed from Homebrew/homebrew-core/Formula/git.rb
+class MicrosoftGit < Formula
+	desc "Distributed revision control system"
+	homepage "https://github.com/microsoft/git"
+	version "2.26.2.vfs.1.1"
+	sha256 "e99fa5e39fa055c318300f65353c8256fca7cc25c16212c73da2081c5a3637f7"
+	url "https://github.com/microsoft/git/archive/v#{version}.tar.gz"
+	head "https://github.com/microsoft/git.git", :shallow => false
+  
+	depends_on "gettext"
+	depends_on "pcre2"
+  
+	if MacOS.version < :yosemite
+	  depends_on "openssl@1.1"
+	  depends_on "curl"
+	end
+  
+	resource "html" do
+	  url "https://www.kernel.org/pub/software/scm/git/git-htmldocs-2.26.2.tar.xz"
+	  sha256 "763c2ab83b980edb210d45d9ad25337afd3610ac3749f4124964f86bbdbb201e"
+	end
+  
+	resource "man" do
+	  url "https://www.kernel.org/pub/software/scm/git/git-manpages-2.26.2.tar.xz"
+	  sha256 "433de104f74a855b7074d88a27e77bf6f0764074e449ffc863f987c124716465"
+	end
+  
+	resource "Net::SMTP::SSL" do
+	  url "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Net-SMTP-SSL-1.04.tar.gz"
+	  sha256 "7b29c45add19d3d5084b751f7ba89a8e40479a446ce21cfd9cc741e558332a00"
+	end
+  
+	# Fixes a bug where fast-forwarding via `git rebase` doesn't work with rebase.abbreviateCommands.
+	# This bug broke `brew update` for some users.
+	# **Please verify the bug is fixed before removing this patch.**
+	# https://github.com/Homebrew/brew/issues/7374
+	patch do
+	  url "https://github.com/agrn/git/commit/058d9c128c63b0a4849b384b358cca9bb19c56db.patch?full_index=1"
+	  sha256 "40a243ccc566721bc4df6d9300772fdd367cb9e35a1652f888b89f3f32823227"
+	end
+  
+	def install
+	  # If these things are installed, tell Git build system not to use them
+	  ENV["NO_FINK"] = "1"
+	  ENV["NO_DARWIN_PORTS"] = "1"
+	  ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
+	  ENV["PYTHON_PATH"] = which("python")
+	  ENV["PERL_PATH"] = which("perl")
+	  ENV["USE_LIBPCRE2"] = "1"
+	  ENV["INSTALL_SYMLINKS"] = "1"
+	  ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
+	  ENV["V"] = "1" # build verbosely
+  
+	  perl_version = Utils.popen_read("perl --version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
+  
+	  ENV["PERLLIB_EXTRA"] = %W[
+		#{MacOS.active_developer_dir}
+		/Library/Developer/CommandLineTools
+		/Applications/Xcode.app/Contents/Developer
+	  ].uniq.map do |p|
+		"#{p}/Library/Perl/#{perl_version}/darwin-thread-multi-2level"
+	  end.join(":")
+  
+	  ENV["NO_PERL_MAKEMAKER"] = "1" unless quiet_system ENV["PERL_PATH"], "-e", "use ExtUtils::MakeMaker"
+  
+	  # Ensure we are using the correct system headers (for curl) to workaround
+	  # mismatched Xcode/CLT versions:
+	  # https://github.com/Homebrew/homebrew-core/issues/46466
+	  if MacOS.version == :mojave && MacOS::CLT.installed? && MacOS::CLT.provides_sdk?
+		ENV["HOMEBREW_SDKROOT"] = MacOS::CLT.sdk_path(MacOS.version)
+	  end
+  
+	  # The git-gui and gitk tools are installed by a separate formula (git-gui)
+	  # to avoid a dependency on tcl-tk and to avoid using the broken system
+	  # tcl-tk (see https://github.com/Homebrew/homebrew-core/issues/36390)
+	  # This is done by setting the NO_TCLTK make variable.
+	  args = %W[
+		prefix=#{prefix}
+		sysconfdir=#{etc}
+		CC=#{ENV.cc}
+		CFLAGS=#{ENV.cflags}
+		LDFLAGS=#{ENV.ldflags}
+		NO_TCLTK=1
+	  ]
+  
+	  if MacOS.version < :yosemite
+		openssl_prefix = Formula["openssl@1.1"].opt_prefix
+		args += %W[NO_APPLE_COMMON_CRYPTO=1 OPENSSLDIR=#{openssl_prefix}]
+	  else
+		args += %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
+	  end
+  
+	  system "make", "install", *args
+  
+	  git_core = libexec/"git-core"
+  
+	  # Install the macOS keychain credential helper
+	  cd "contrib/credential/osxkeychain" do
+		system "make", "CC=#{ENV.cc}",
+					   "CFLAGS=#{ENV.cflags}",
+					   "LDFLAGS=#{ENV.ldflags}"
+		git_core.install "git-credential-osxkeychain"
+		system "make", "clean"
+	  end
+  
+	  # Generate diff-highlight perl script executable
+	  cd "contrib/diff-highlight" do
+		system "make"
+	  end
+  
+	  # Install the netrc credential helper
+	  cd "contrib/credential/netrc" do
+		system "make", "test"
+		git_core.install "git-credential-netrc"
+	  end
+  
+	  # Install git-subtree
+	  cd "contrib/subtree" do
+		system "make", "CC=#{ENV.cc}",
+					   "CFLAGS=#{ENV.cflags}",
+					   "LDFLAGS=#{ENV.ldflags}"
+		git_core.install "git-subtree"
+	  end
+  
+	  # install the completion script first because it is inside "contrib"
+	  bash_completion.install "contrib/completion/git-completion.bash"
+	  bash_completion.install "contrib/completion/git-prompt.sh"
+	  zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
+	  cp "#{bash_completion}/git-completion.bash", zsh_completion
+  
+	  elisp.install Dir["contrib/emacs/*.el"]
+	  (share/"git-core").install "contrib"
+  
+	  # We could build the manpages ourselves, but the build process depends
+	  # on many other packages, and is somewhat crazy, this way is easier.
+	  man.install resource("man")
+	  (share/"doc/git-doc").install resource("html")
+  
+	  # Make html docs world-readable
+	  chmod 0644, Dir["#{share}/doc/git-doc/**/*.{html,txt}"]
+	  chmod 0755, Dir["#{share}/doc/git-doc/{RelNotes,howto,technical}"]
+  
+	  # To avoid this feature hooking into the system OpenSSL, remove it
+	  rm "#{libexec}/git-core/git-imap-send" if MacOS.version >= :yosemite
+  
+	  # git-send-email needs Net::SMTP::SSL
+	  resource("Net::SMTP::SSL").stage do
+		(share/"perl5").install "lib/Net"
+	  end
+  
+	  # This is only created when building against system Perl, but it isn't
+	  # purged by Homebrew's post-install cleaner because that doesn't check
+	  # "Library" directories. It is however pointless to keep around as it
+	  # only contains the perllocal.pod installation file.
+	  rm_rf prefix/"Library/Perl"
+  
+	  # Set the macOS keychain credential helper by default
+	  # (as Apple's CLT's git also does this).
+	  (buildpath/"gitconfig").write <<~EOS
+		[credential]
+		\thelper = osxkeychain
+	  EOS
+	  etc.install "gitconfig"
+	end
+  
+	def caveats
+	  <<~EOS
+		The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.
+	  EOS
+	end
+  
+	test do
+	  system bin/"git", "init"
+	  %w[haunted house].each { |f| touch testpath/f }
+	  system bin/"git", "add", "haunted", "house"
+	  system bin/"git", "commit", "-a", "-m", "Initial Commit"
+	  assert_equal "haunted\nhouse", shell_output("#{bin}/git ls-files").strip
+  
+	  # Check Net::SMTP::SSL was installed correctly.
+	  %w[foo bar].each { |f| touch testpath/f }
+	  system bin/"git", "add", "foo", "bar"
+	  system bin/"git", "commit", "-a", "-m", "Second Commit"
+	  assert_match "Authentication Required", pipe_output(
+		"#{bin}/git send-email --from=test@example.com --to=dev@null.com " \
+		"--smtp-server=smtp.gmail.com --smtp-server-port=587 " \
+		"--smtp-encryption=tls --confirm=never HEAD^ 2>&1",
+	  )
+	end
+end

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,33 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This repository for homebrew-git includes material from the
+projects listed below.
+
+1. Homebrew/homebrew-core (https://github.com/Homebrew/homebrew-core)
+
+BSD 2-Clause License
+
+Copyright (c) 2009-present, Homebrew contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Install with `brew cask install <cask>`
 
 - [Git Credential Manager Core](https://aka.ms/gcmcore) (`git-credential-manager-core`)
 - [Scalar](https://github.com/microsoft/scalar) (`scalar`)
+- [Scalar for Azure Repos](https://github.com/microsoft/scalar) (`scalar-azrepos`)
 
 Please report any product bugs and issues in their respective projects.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following packages are available in this Tap:
 
 Install with `brew install <formula>`
 
-- _none_
+- [Microsoft Git](https://github.com/microsoft/git) (`microsoft-git`)
 
 ### Casks
 


### PR DESCRIPTION
Add both a `microsoft-git` Formula and a `scalar-azrepos` Cask. The dependencies of all current packages looks like this:

```
+--------+  +----------------+
| scalar |  | scalar-azrepos |
|  Cask  |  |      Cask      |
+----+---+  +-------+--------+
     |              |
     +----------------------------------------+
     |              |                         |
     |              +-------------------------+
     |              |                         |
     |              |                         |
     v              v                         v
+----+----+  +------+--------+  +-------------+---------------+
|   git   |  | microsoft-git |  | git-credential-manager-core |
| Formula |  |    Formula    |  |            Cask             |
+---------+  +---------------+  +-----------------------------+
```

The reason to have `scalar-azrepos` is that it also takes a dependency on the microsoft/git fork, which some might not want to do. Both `scalar` and `scalar-azrepos` will install GCM Core. The `scalar` and `scalar-azrepos` Casks declare that they conflict with each other so you should only be able to install one or the other.

The `git` Formula comes from the `homebrew-core` Tap. The `microsoft-git` Formula is based on the `git` Formula.
Prebuilt binaries (Bottles) can be provided for our `microsoft/git` fork, but we'd need to set these up and host the blobs in Azure (I have a working example of this).