### PR TITLE
scalar/scalar-azrepos: add watchman dependency

### DIFF
--- a/Casks/scalar-azrepos.rb
+++ b/Casks/scalar-azrepos.rb
@@ -12,6 +12,7 @@ cask 'scalar-azrepos' do
   conflicts_with cask: 'scalar'
 
   depends_on formula: 'microsoft-git'
+  depends_on formula: 'watchman'
   depends_on cask: 'git-credential-manager-core'
 
   uninstall script: {

--- a/Casks/scalar.rb
+++ b/Casks/scalar.rb
@@ -12,6 +12,7 @@ cask 'scalar' do
   conflicts_with cask: 'scalar-azrepos'
 
   depends_on formula: 'git'
+  depends_on formula: 'watchman'
   depends_on cask: 'git-credential-manager-core'
 
   uninstall script: {


### PR DESCRIPTION
Add a dependency on the `watchman` formula for both the `scalar` and `scalar-azrepos` Casks. Although Watchman is not a hard requirement to use Scalar, it is recommended to get the best performance (which is probably the reason for using Scalar in the first place).

Once the built-in FSMonitor is working on all platforms, we can drop this dependency.