### PR TITLE
scalar[-azrepos]: drop watchman from dependencies

### DIFF
--- a/Casks/scalar-azrepos.rb
+++ b/Casks/scalar-azrepos.rb
@@ -12,7 +12,6 @@ cask 'scalar-azrepos' do
   conflicts_with cask: 'scalar'
 
   depends_on cask: 'microsoft-git'
-  depends_on formula: 'watchman'
   depends_on cask: 'git-credential-manager-core'
 
   uninstall script: {

--- a/Casks/scalar.rb
+++ b/Casks/scalar.rb
@@ -12,7 +12,6 @@ cask 'scalar' do
   conflicts_with cask: 'scalar-azrepos'
 
   depends_on formula: 'git'
-  depends_on formula: 'watchman'
   depends_on cask: 'git-credential-manager-core'
 
   uninstall script: {


### PR DESCRIPTION
Users will need to install this manually, but this allows build machines
to skip this step.