### PR TITLE
GCM Core: use non-beta URL

### DIFF
--- a/Casks/git-credential-manager-core.rb
+++ b/Casks/git-credential-manager-core.rb
@@ -5,7 +5,7 @@ cask 'git-credential-manager-core' do
   version "2.0.452.3248"
   sha256 '8026fa9589a41d5a7b56e17f7001f84053d05eab03d0381097d1696dca43ae78'
 
-  url "https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v#{version.major_minor_patch}-beta/gcmcore-osx-#{version}.pkg"
+  url "https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v#{version.major_minor_patch}/gcmcore-osx-#{version}.pkg"
 
   pkg "gcmcore-osx-#{version}.pkg", allow_untrusted: true
 


### PR DESCRIPTION
The previous release in #40 updated a release, but the new release uses a different URL model.

Fixes microsoft/Git-Credential-Manager-Core#351.