### PR TITLE
Add GCM-Core as a dependency

### DIFF
--- a/Casks/microsoft-git.rb
+++ b/Casks/microsoft-git.rb
@@ -10,6 +10,8 @@ cask 'microsoft-git' do
   pkg "git-#{version}-intel-universal-snow-leopard.pkg", allow_untrusted: true
 
   conflicts_with formula: 'git'
+  
+  depends_on cask: 'git-credential-manager-core'
 
   uninstall script: {
             executable: '/usr/local/git/uninstall.sh',


### PR DESCRIPTION
If this was intentionally left out and the intention is for users to explicitly install both if they need GCM-Core I'd be happy closing this PR. In order to protect ourselves in Office Engineering we will be making that change anyways. But this seems helpful for an average user trying to use Microsoft Git on Mac. 