### PR TITLE
Update GCM Cask with new asset name

### DIFF
--- a/Casks/git-credential-manager-core.rb
+++ b/Casks/git-credential-manager-core.rb
@@ -5,7 +5,7 @@ cask 'git-credential-manager-core' do
   version "2.0.632.34631"
   sha256 'cf75b5d082c103e63cee70dd70aa968b7f9ca1dbf10aad49d6c2309927757cc1'
 
-  url "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcmcore-osx-#{version}.pkg"
+  url "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcmcore-osx-#{version.major_minor_patch}.pkg"
 
   pkg "gcmcore-osx-#{version}.pkg", allow_untrusted: true
 


### PR DESCRIPTION
GCM pkg installer was changed to drop the 4th build component from the file name.
Update the `url` field to use major.minor.patch only.