### PR TITLE
gcm: remove prefix differentiation

### DIFF
--- a/Casks/git-credential-manager-core.rb
+++ b/Casks/git-credential-manager-core.rb
@@ -1,6 +1,5 @@
 cask 'git-credential-manager-core' do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
-  prefix = Hardware::CPU.intel? ? "/usr/local" : "/opt/homebrew"
   name 'Git Credential Manager'
   homepage 'https://aka.ms/gcm'
 
@@ -14,7 +13,7 @@ cask 'git-credential-manager-core' do
   url "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcm-osx-#{arch}-#{version.major_minor_patch}.pkg"
   pkg "gcm-osx-#{arch}-#{version}.pkg", allow_untrusted: true
   uninstall script: {
-                      executable: "#{prefix}/share/gcm-core/uninstall.sh",
+                      executable: "/usr/local/share/gcm-core/uninstall.sh",
                       sudo:       true,
                     },
             pkgutil: 'com.microsoft.GitCredentialManager'


### PR DESCRIPTION
While Homebrew changed its prefix on Apple Silicon from /usr/local to /opt/homebrew, we actually did not need to follow suit for the following reasons:

1. We’re a cask and installed via .pkg, so we don’t have to be limited to set install directories.
2. It’s simpler to /usr/local/share for all supported architectures.
3. Similar tools use this path, like powershell and dotnet.

Thus, removing the prefix differentiation with this change.

Fixes #70 