### PR TITLE
docs: remove GCM from list of casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Install with `brew install <formula>`
 
 Install with `brew install --cask <cask>`
 
-- [Git Credential Manager Core](https://aka.ms/gcmcore) (`git-credential-manager-core`)
 - [Microsoft Git](https://github.com/microsoft/git) (`microsoft-git`)
 - [Scalar](https://github.com/microsoft/scalar) (`scalar`)
 - [Scalar for Azure Repos](https://github.com/microsoft/scalar) (`scalar-azrepos`)


### PR DESCRIPTION
Remove Git Credential Manager from the list of available casks in this tap, since it was migrated to Homebrew/homebrew-cask with [1].

1: https://github.com/Homebrew/homebrew-cask/pull/152552