### PR TITLE
Remove -core from GCM name

### DIFF
--- a/Casks/microsoft-git.rb
+++ b/Casks/microsoft-git.rb
@@ -11,7 +11,7 @@ cask 'microsoft-git' do
 
   conflicts_with formula: 'git'
   
-  depends_on cask: 'git-credential-manager-core'
+  depends_on cask: 'git-credential-manager'
 
   uninstall script: {
             executable: '/usr/local/git/uninstall.sh',

--- a/Casks/microsoft-git.rb
+++ b/Casks/microsoft-git.rb
@@ -11,7 +11,7 @@ cask 'microsoft-git' do
 
   conflicts_with formula: 'git'
   
-  depends_on cask: 'git-credential-manager'
+  depends_on cask: 'homebrew/cask/git-credential-manager'
 
   uninstall script: {
             executable: '/usr/local/git/uninstall.sh',


### PR DESCRIPTION
Attempt to update the git cask `depends_on` req to the new GCM cask to unblock installing the git cask. 

This is untested, and is just a suggestion to try since we are actively blocked. 