### PR TITLE
dependencies: update references to GCM

### DIFF
--- a/Casks/scalar-azrepos.rb
+++ b/Casks/scalar-azrepos.rb
@@ -12,7 +12,7 @@ cask 'scalar-azrepos' do
   conflicts_with cask: 'scalar'
 
   depends_on cask: 'microsoft-git'
-  depends_on cask: 'git-credential-manager-core'
+  depends_on cask: 'homebrew/cask/git-credential-manager'
 
   uninstall script: {
                       executable: '/usr/local/scalar/uninstall_scalar.sh',

--- a/Casks/scalar.rb
+++ b/Casks/scalar.rb
@@ -12,7 +12,7 @@ cask 'scalar' do
   conflicts_with cask: 'scalar-azrepos'
 
   depends_on formula: 'git'
-  depends_on cask: 'git-credential-manager-core'
+  depends_on cask: 'homebrew/cask/git-credential-manager'
 
   uninstall script: {
                       executable: '/usr/local/scalar/uninstall_scalar.sh',


### PR DESCRIPTION
The `scalar` and `scalar-azrepos` casks currently reference the old `git-credential-manager-core` cask as a dependency. Update this to reference the new `git-credential-manager` cask located [here]( https://github.com/Homebrew/homebrew-cask/blob/master/Casks/g/git-credential-manager.rb).

Note: microsoft/git was updated to point at the new cask with [this PR](https://github.com/microsoft/homebrew-git/pull/75).