### PR TITLE
Remove conflicts with formula

### DIFF
--- a/Casks/microsoft-git.rb
+++ b/Casks/microsoft-git.rb
@@ -8,8 +8,6 @@ cask 'microsoft-git' do
   url "https://github.com/microsoft/git/releases/download/v#{version}/git-#{version}-universal.pkg"
 
   pkg "git-#{version}-universal.pkg", allow_untrusted: true
-
-  conflicts_with formula: 'git'
   
   depends_on cask: 'homebrew/cask/git-credential-manager'
 

--- a/Casks/microsoft-git.rb
+++ b/Casks/microsoft-git.rb
@@ -12,9 +12,9 @@ cask 'microsoft-git' do
   depends_on cask: 'homebrew/cask/git-credential-manager'
 
   uninstall script: {
-            executable: '/usr/local/git/uninstall.sh',
-            args:       ['--yes'],
-            sudo:       true,
-            },
-        pkgutil: 'com.git.pkg'
+                      executable: '/usr/local/git/uninstall.sh',
+                      args:       ['--yes'],
+                      sudo:       true,
+                    },
+            pkgutil: 'com.git.pkg'
 end


### PR DESCRIPTION
According to https://github.com/Homebrew/brew/pull/20499 this functionality was never implemented. Since 4.6.5 (see [release notes](https://github.com/Homebrew/brew/releases/tag/4.6.5)), Homebrew generates a deprecation warning every time this cask is installed (e.g. via `git update-microsoft-git`):

<img width="719" height="186" alt="image" src="https://github.com/user-attachments/assets/dcf2fb47-a8a5-42f6-9f7a-e4f6d690f97e" />
